### PR TITLE
Fix/server listing exclusion

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,16 @@
 # Changelog
+## [v1.2.1] - 2025-05-16
+
+### Fixed:
+- Improved output for `-e` and `-l` options to work without verbosity.
+- Allowed `-e` to function without `-u` when viewing exclusions.
+- Handled missing `-u` option gracefully to prevent exceptions.
+- Included server tags in the exclusions list.
+- Corrected display of server ports in the server listing.
+- Filtered out non-supported outbound types from the server list.
+- Ensured server index numbers start at 0 and match the `-i` index.
+
+---
 
 ## [v1.2.0] - 2025-05-15
 

--- a/modules/server_management.py
+++ b/modules/server_management.py
@@ -71,25 +71,31 @@ def apply_exclusions(configs, excluded_ids, debug_level):
         valid_configs.append(config)
     return valid_configs
 
-def exclude_servers(json_data, exclude_list, debug_level=0):
+def exclude_servers(json_data, exclude_list, supported_protocols, debug_level=0):
     """Exclude servers by index or name, supporting wildcards."""
     exclusions = load_exclusions()
     servers = json_data.get("outbounds", json_data)
     new_exclusions = []
 
+    # Create a list of supported servers with their indices
+    supported_servers = [
+        (idx, server) for idx, server in enumerate(servers)
+        if server.get("type") in supported_protocols
+    ]
+
     for item in exclude_list:
         if item.isdigit():
             # Exclude by index
             index = int(item)
-            if 0 <= index < len(servers):
-                server = servers[index]
+            if 0 <= index < len(supported_servers):
+                _, server = supported_servers[index]
                 server_id = generate_server_id(server)
                 new_exclusions.append({"id": server_id, "name": server.get("tag", "N/A")})
                 if debug_level >= 0:
                     print(f"Excluding server by index {index}: {server.get('tag', 'N/A')}")
         else:
             # Exclude by name with wildcard support
-            for server in servers:
+            for _, server in supported_servers:
                 if fnmatch.fnmatch(server.get("tag", ""), item):
                     server_id = generate_server_id(server)
                     new_exclusions.append({"id": server_id, "name": server.get("tag", "N/A")})

--- a/modules/server_management.py
+++ b/modules/server_management.py
@@ -7,9 +7,8 @@ import shutil
 import datetime
 
 EXCLUSION_FILE = os.getenv("SINGBOX_EXCLUSION_FILE", "./exclusions.json")
-SUPPORTED_PROTOCOLS = ["direct", "block", "dns"]
 
-def list_servers(json_data, debug_level=0):
+def list_servers(json_data, supported_protocols, debug_level=0):
     """List all supported outbounds with indices and details."""
     if isinstance(json_data, dict) and "outbounds" in json_data:
         servers = json_data["outbounds"]
@@ -22,7 +21,7 @@ def list_servers(json_data, debug_level=0):
     index = 0
     for server in servers:
         # Only list supported outbounds
-        if server.get("type") not in SUPPORTED_PROTOCOLS:
+        if server.get("type") not in supported_protocols:
             continue
         # Extract the name from the 'tag' field if available
         name = server.get("tag", "N/A")

--- a/modules/server_management.py
+++ b/modules/server_management.py
@@ -33,8 +33,8 @@ def list_servers(json_data, supported_protocols, debug_level=0):
         index += 1
 
 def generate_server_id(server):
-    """Generate a unique ID for a server based on name, protocol, and port."""
-    identifier = f"{server.get('name', '')}{server.get('type', '')}{server.get('port', '')}"
+    """Generate a unique ID for a server based on tag, protocol, and port."""
+    identifier = f"{server.get('tag', '')}{server.get('type', '')}{server.get('server_port', '')}"
     return hashlib.sha256(identifier.encode()).hexdigest()
 
 def handle_temp_file(content, target_path, validate_fn):

--- a/modules/server_management.py
+++ b/modules/server_management.py
@@ -10,7 +10,7 @@ EXCLUSION_FILE = os.getenv("SINGBOX_EXCLUSION_FILE", "./exclusions.json")
 SUPPORTED_PROTOCOLS = ["direct", "block", "dns"]
 
 def list_servers(json_data, debug_level=0):
-    """List all outbounds with indices and details."""
+    """List all supported outbounds with indices and details."""
     if isinstance(json_data, dict) and "outbounds" in json_data:
         servers = json_data["outbounds"]
     else:
@@ -101,13 +101,12 @@ def exclude_servers(json_data, exclude_list, debug_level=0):
     exclusions["exclusions"].extend(new_exclusions)
     save_exclusions(exclusions)
 
-def view_exclusions(debug_level):
+def view_exclusions(debug_level=0):
     """View current exclusions."""
     exclusions = load_exclusions()
-    if debug_level >= 1:
-        print("Current Exclusions:")
-        for exclusion in exclusions["exclusions"]:
-            print(f"ID: {exclusion['id']}, Name: {exclusion['name']}, Reason: {exclusion.get('reason', 'N/A')}")
+    print("Current Exclusions:")
+    for exclusion in exclusions["exclusions"]:
+        print(f"ID: {exclusion['id']}, Name: {exclusion['name']}, Reason: {exclusion.get('reason', 'N/A')}")
     if debug_level >= 2:
         print(json.dumps(exclusions, indent=2))
 

--- a/modules/server_management.py
+++ b/modules/server_management.py
@@ -7,26 +7,31 @@ import shutil
 import datetime
 
 EXCLUSION_FILE = os.getenv("SINGBOX_EXCLUSION_FILE", "./exclusions.json")
+SUPPORTED_PROTOCOLS = ["direct", "block", "dns"]
 
-def list_servers(json_data):
+def list_servers(json_data, debug_level=0):
     """List all outbounds with indices and details."""
     if isinstance(json_data, dict) and "outbounds" in json_data:
         servers = json_data["outbounds"]
     else:
         servers = json_data
 
-    print("Index | Name | Protocol | Port")
-    print("--------------------------------")
-    for idx, server in enumerate(servers):
-        # Only list outbounds, not inbounds
-        if server.get("type") in {"direct", "block", "dns"}:
+    if debug_level >= 0:
+        print("Index | Name | Protocol | Port")
+        print("--------------------------------")
+    index = 0
+    for server in servers:
+        # Only list supported outbounds
+        if server.get("type") not in SUPPORTED_PROTOCOLS:
             continue
         # Extract the name from the 'tag' field if available
         name = server.get("tag", "N/A")
         protocol = server.get("type", "N/A")
         # Extract the port from the server configuration
-        port = server.get("port", "N/A")
-        print(f"{idx} | {name} | {protocol} | {port}")
+        port = server.get("server_port", "N/A")
+        if debug_level >= 0:
+            print(f"{index} | {name} | {protocol} | {port}")
+        index += 1
 
 def generate_server_id(server):
     """Generate a unique ID for a server based on name, protocol, and port."""
@@ -67,7 +72,7 @@ def apply_exclusions(configs, excluded_ids, debug_level):
         valid_configs.append(config)
     return valid_configs
 
-def exclude_servers(json_data, exclude_list, debug_level):
+def exclude_servers(json_data, exclude_list, debug_level=0):
     """Exclude servers by index or name, supporting wildcards."""
     exclusions = load_exclusions()
     servers = json_data.get("outbounds", json_data)
@@ -80,17 +85,17 @@ def exclude_servers(json_data, exclude_list, debug_level):
             if 0 <= index < len(servers):
                 server = servers[index]
                 server_id = generate_server_id(server)
-                new_exclusions.append({"id": server_id, "name": server.get("name", "N/A")})
-                if debug_level >= 1:
-                    print(f"Excluding server by index {index}: {server.get('name', 'N/A')}")
+                new_exclusions.append({"id": server_id, "name": server.get("tag", "N/A")})
+                if debug_level >= 0:
+                    print(f"Excluding server by index {index}: {server.get('tag', 'N/A')}")
         else:
             # Exclude by name with wildcard support
             for server in servers:
-                if fnmatch.fnmatch(server.get("name", ""), item):
+                if fnmatch.fnmatch(server.get("tag", ""), item):
                     server_id = generate_server_id(server)
-                    new_exclusions.append({"id": server_id, "name": server.get("name", "N/A")})
-                    if debug_level >= 1:
-                        print(f"Excluding server by name {server.get('name', 'N/A')}")
+                    new_exclusions.append({"id": server_id, "name": server.get("tag", "N/A")})
+                    if debug_level >= 0:
+                        print(f"Excluding server by name {server.get('tag', 'N/A')}")
 
     # Update exclusions
     exclusions["exclusions"].extend(new_exclusions)

--- a/update_singbox.py
+++ b/update_singbox.py
@@ -87,6 +87,8 @@ def main():
             view_exclusions(args.debug)
         else:
             if json_data:
+                # Ensure indices match the displayed list
+                list_servers(json_data, SUPPORTED_PROTOCOLS, args.debug)
                 exclude_servers(json_data, args.exclude, args.debug)
                 generate_config_after_exclusion(json_data, args.debug)
             else:
@@ -184,12 +186,10 @@ def generate_config_after_exclusion(json_data, debug_level):
     for idx, config in enumerate(configs):
         try:
             outbound = validate_protocol(config, SUPPORTED_PROTOCOLS)
-            # Use original tag if available, else generate proxy-a, proxy-b, etc.
-            if not outbound["tag"].startswith("proxy-"):
-                outbounds.append(outbound)
-            else:
+            # Ensure each outbound has a unique tag
+            if not outbound.get("tag"):
                 outbound["tag"] = f"proxy-{chr(97 + idx)}"
-                outbounds.append(outbound)
+            outbounds.append(outbound)
         except ValueError as e:
             logging.warning(f"Skipping invalid configuration at index {idx}: {e}")
 

--- a/update_singbox.py
+++ b/update_singbox.py
@@ -58,6 +58,7 @@ def main():
     parser.add_argument("--clear-exclusions", action="store_true", help="Clear all current exclusions")
     args = parser.parse_args()
 
+    # Initialize logging
     setup_logging(args.debug, LOG_FILE, MAX_LOG_SIZE)
     logging.info("=== Starting sing-box configuration update ===")
 

--- a/update_singbox.py
+++ b/update_singbox.py
@@ -87,9 +87,7 @@ def main():
             view_exclusions(args.debug)
         else:
             if json_data:
-                # Ensure indices match the displayed list
-                list_servers(json_data, SUPPORTED_PROTOCOLS, args.debug)
-                exclude_servers(json_data, args.exclude, args.debug)
+                exclude_servers(json_data, args.exclude, SUPPORTED_PROTOCOLS, args.debug)
                 generate_config_after_exclusion(json_data, args.debug)
             else:
                 print("Error: URL is required to exclude servers.")

--- a/update_singbox.py
+++ b/update_singbox.py
@@ -76,7 +76,7 @@ def main():
     # List servers if requested
     if args.list_servers:
         if json_data:
-            list_servers(json_data, args.debug)
+            list_servers(json_data, SUPPORTED_PROTOCOLS, args.debug)
         else:
             print("Error: URL is required to list servers.")
         return


### PR DESCRIPTION
## [v1.2.1] - 2025-05-16

### Fixed:
- Improved output for `-e` and `-l` options to work without verbosity.
- Allowed `-e` to function without `-u` when viewing exclusions.
- Handled missing `-u` option gracefully to prevent exceptions.
- Included server tags in the exclusions list.
- Corrected display of server ports in the server listing.
- Filtered out non-supported outbound types from the server list.
- Ensured server index numbers start at 0 and match the `-i` index.

