### PR TITLE
feat: add --dry-run option for safe config generation and validation

### DIFF
--- a/modules/config_generate.py
+++ b/modules/config_generate.py
@@ -72,3 +72,36 @@ def generate_config(outbounds, template_file, config_file, backup_file, excluded
     os.rename(temp_config_file, config_file)
     info(f"Configuration updated with {len(outbounds)} outbounds")
     return True
+
+def generate_temp_config(outbounds, template_file, excluded_ips):
+    """Генерирует json-строку конфига для dry-run без записи в файл."""
+    if not os.path.exists(template_file):
+        error(f"Template file not found: {template_file}")
+        raise FileNotFoundError(f"Template file not found: {template_file}")
+    with open(template_file) as f:
+        template = json.load(f)
+    outbound_tags = [outbound["tag"] for outbound in outbounds] if outbounds else []
+    for outbound in template["outbounds"]:
+        if outbound.get("type") == "urltest" and outbound.get("tag") == "auto":
+            outbound["outbounds"] = outbound_tags
+            break
+    urltest_idx = next(
+        (i for i, o in enumerate(template["outbounds"]) if o.get("tag") == "auto"),
+        0
+    )
+    template["outbounds"] = (
+        template["outbounds"][:urltest_idx + 1] +
+        outbounds +
+        template["outbounds"][urltest_idx + 1:]
+    )
+    excluded_ips_cidr = [f"{ip}/32" for ip in excluded_ips]
+    for rule in template["route"]["rules"]:
+        if rule.get("ip_cidr") == "$excluded_servers":
+            rule["ip_cidr"] = excluded_ips_cidr
+    return json.dumps(template, indent=2)
+
+def validate_config_file(config_path):
+    """Валидирует конфиг-файл через sing-box check. Возвращает (bool, вывод)."""
+    import subprocess
+    result = subprocess.run(["sing-box", "check", "-c", config_path], capture_output=True, text=True)
+    return result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION

What’s new

    Introduced the --dry-run flag to the sing-box config update script.
    In dry-run mode:
     -   A temporary config file is generated based on the current parameters.
     -   The config is validated using sing-box check.
     -   The main config file is not overwritten and the service is not restarted.
     -   All dry-run steps are logged for transparency.
    Utility functions for temporary config generation and validation are added for reuse.

Why

    Allows safe testing of config generation and structure without risking the production config or service downtime.
    Useful for CI/CD, debugging templates, and checking new config sources.

Usage:
```
python3 update_singbox.py --dry-run -u <URL>
```